### PR TITLE
Start frontend application

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -47,6 +47,7 @@
         "cmdk": "^1.1.1",
         "date-fns": "^4.1.0",
         "embla-carousel-react": "^8.5.1",
+        "es-toolkit": "^1.39.9",
         "framer-motion": "^12.23.12",
         "lucide-react": "^0.539.0",
         "postcss": "^8.5.6",
@@ -99,7 +100,7 @@
         "prettier": "^3.3.3",
         "typescript": "~5.8.3",
         "typescript-eslint": "^8.39.0",
-        "vite": "^7.1.0",
+        "vite": "^7.1.2",
         "vitest": "^2.1.4"
       }
     },


### PR DESCRIPTION
## Summary

- This PR updates `frontend/package-lock.json` to reflect the current state of installed dependencies. This change occurred as a result of running `npm install` to start the frontend development server, which pulled in `es-toolkit` and updated `vite` to a newer patch version.

## Checklist

- [ ] I ran unit tests and they pass locally
- [ ] I verified dev servers for backend (8000) and frontend (4000) work together
- [ ] I ran linters/formatters (ESLint/Prettier, Black/Flake8)
- [ ] I did not change public API contracts without updating docs/tests
- [ ] I preserved indentation style and avoided unrelated reformatting
- [ ] I updated docs and changelogs if needed

## AI Contributor Acknowledgement

If AI assistance (Cursor, Copilot, Claude, etc.) was used:

- [ ] I followed the repository's AI development guidelines
- [ ] I performed a discovery pass before edits and minimized unrelated changes
- [ ] I validated all generated code, removed speculation, and ensured correctness

## Screenshots / Test Evidence

---
<a href="https://cursor.com/background-agent?bcId=bc-02bec336-9fee-4b0f-844f-2f87ec342608">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-02bec336-9fee-4b0f-844f-2f87ec342608">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

