### PR TITLE
Investigate and resolve backend cpu usage

### DIFF
--- a/backend/core/monitoring.py
+++ b/backend/core/monitoring.py
@@ -109,7 +109,7 @@ class AsyncPerformanceMonitor:
         try:
             # System metrics
             memory = psutil.virtual_memory()
-            cpu_percent = psutil.cpu_percent(interval=1)
+            cpu_percent = psutil.cpu_percent(interval=0.0)
 
             # Application metrics
             metrics = ConcurrencyMetrics(

--- a/backend/core/task_optimizer.py
+++ b/backend/core/task_optimizer.py
@@ -39,7 +39,7 @@ class TaskResourceMonitor:
         # Collect fresh metrics
         try:
             metrics = {
-                'cpu_percent': psutil.cpu_percent(interval=1),
+                'cpu_percent': psutil.cpu_percent(interval=0.0),
                 'memory_percent': psutil.virtual_memory().percent,
                 'disk_percent': psutil.disk_usage('/').percent,
                 'load_avg': psutil.getloadavg()[0] if hasattr(psutil, 'getloadavg') else 0,

--- a/backend/routers/admin_cleaned.py
+++ b/backend/routers/admin_cleaned.py
@@ -885,7 +885,7 @@ async def get_monitoring_metrics(
         import platform
         
         # Get real system metrics
-        cpu_percent = psutil.cpu_percent(interval=1)
+        cpu_percent = psutil.cpu_percent(interval=0.0)
         memory = psutil.virtual_memory()
         disk = psutil.disk_usage('/')
         network = psutil.net_io_counters()
@@ -1144,7 +1144,7 @@ async def get_performance_metrics(
         import time as time_module
         
         # Get current system performance
-        cpu_percent = psutil.cpu_percent(interval=1)
+        cpu_percent = psutil.cpu_percent(interval=0.0)
         memory = psutil.virtual_memory()
         disk = psutil.disk_usage('/')
         network = psutil.net_io_counters()
@@ -1556,7 +1556,7 @@ async def get_system_status(
         import platform
         
         # System information
-        cpu_percent = psutil.cpu_percent(interval=1)
+        cpu_percent = psutil.cpu_percent(interval=0.0)
         memory = psutil.virtual_memory()
         disk = psutil.disk_usage('/')
         

--- a/backend/routers/admin_fixed.py
+++ b/backend/routers/admin_fixed.py
@@ -66,7 +66,7 @@ async def get_admin_dashboard(
         
         # Add system metrics
         system_metrics = {
-            'cpu_percent': psutil.cpu_percent(interval=1),
+            'cpu_percent': psutil.cpu_percent(interval=0.0),
             'memory_percent': psutil.virtual_memory().percent,
             'disk_percent': psutil.disk_usage('/').percent,
             'system_load_avg': psutil.getloadavg()[0] if hasattr(psutil, 'getloadavg') else 0.0
@@ -339,7 +339,7 @@ async def get_admin_statistics(
         
         # System health
         system_health = {
-            'cpu_percent': psutil.cpu_percent(interval=1),
+            'cpu_percent': psutil.cpu_percent(interval=0.0),
             'memory_percent': psutil.virtual_memory().percent,
             'disk_percent': psutil.disk_usage('/').percent,
             'uptime_hours': (datetime.utcnow() - datetime.fromtimestamp(psutil.boot_time())).total_seconds() / 3600

--- a/backend/routers/metrics.py
+++ b/backend/routers/metrics.py
@@ -90,7 +90,7 @@ async def get_system_metrics() -> dict[str, Any]:
     """Get detailed system metrics."""
     try:
         memory = psutil.virtual_memory()
-        cpu_percent = psutil.cpu_percent(interval=1)
+        cpu_percent = psutil.cpu_percent(interval=0.0)
         disk = psutil.disk_usage('/')
         
         return {
@@ -156,7 +156,7 @@ async def get_realtime_metrics() -> dict[str, Any]:
     """Get real-time system metrics."""
     try:
         memory = psutil.virtual_memory()
-        cpu_percent = psutil.cpu_percent(interval=1)
+        cpu_percent = psutil.cpu_percent(interval=0.0)
         
         return {
             "timestamp": datetime.utcnow().isoformat(),
@@ -214,7 +214,7 @@ async def get_admin_overview(
 
         # System overview
         memory = psutil.virtual_memory()
-        cpu_percent = psutil.cpu_percent(interval=1)
+        cpu_percent = psutil.cpu_percent(interval=0.0)
 
         return {
             "timestamp": datetime.utcnow().isoformat(),

--- a/backend/routers/observability.py
+++ b/backend/routers/observability.py
@@ -64,7 +64,7 @@ async def get_metrics():
         # Update system metrics
         memory = psutil.virtual_memory()
         SYSTEM_MEMORY_USAGE.set(memory.used)
-        SYSTEM_CPU_USAGE.set(psutil.cpu_percent())
+        SYSTEM_CPU_USAGE.set(psutil.cpu_percent(interval=0.0))
 
         # Update database connection metrics
         try:

--- a/backend/routers/performance.py
+++ b/backend/routers/performance.py
@@ -73,7 +73,7 @@ async def performance_status(
     import psutil
 
     # Get system metrics
-    cpu_percent = psutil.cpu_percent(interval=0.1)
+    cpu_percent = psutil.cpu_percent(interval=0.0)
     memory = psutil.virtual_memory()
     disk = psutil.disk_usage("/")
 
@@ -126,7 +126,7 @@ async def get_system_check(
         import psutil
 
         return {
-            "cpu_usage": psutil.cpu_percent(),
+            "cpu_usage": psutil.cpu_percent(interval=0.0),
             "memory_usage": psutil.virtual_memory().percent,
             "disk_usage": psutil.disk_usage("/").percent,
             "system_healthy": True,
@@ -286,7 +286,7 @@ async def get_current_metrics(
         import psutil
 
         return PerformanceMetrics(
-            cpu_usage=psutil.cpu_percent(),
+            cpu_usage=psutil.cpu_percent(interval=0.0),
             memory_usage=psutil.virtual_memory().percent,
             response_time=125.0,
             throughput=150.0,
@@ -310,7 +310,7 @@ async def get_live_metrics(
         return LivePerformanceStream(
             timestamp=datetime.utcnow(),
             metrics=PerformanceMetrics(
-                cpu_usage=psutil.cpu_percent(),
+                cpu_usage=psutil.cpu_percent(interval=0.0),
                 memory_usage=psutil.virtual_memory().percent,
                 response_time=125.0,
                 throughput=150.0,

--- a/backend/tasks/load_balancer_tasks.py
+++ b/backend/tasks/load_balancer_tasks.py
@@ -143,7 +143,7 @@ class LoadBalancer:
 
     def _get_system_load(self) -> dict[str, float]:
         """Get current system resource utilization"""
-        cpu_percent = psutil.cpu_percent(interval=1)
+        cpu_percent = psutil.cpu_percent(interval=0.0)
         memory = psutil.virtual_memory()
 
         return {


### PR DESCRIPTION
## Summary

- This PR addresses potential high CPU usage by modifying `psutil.cpu_percent` calls in various metrics and health endpoints to be non-blocking (setting `interval=0.0`). This change prevents these monitoring calls from introducing their own CPU overhead, especially in frequently accessed endpoints.

## Checklist

- [ ] I ran unit tests and they pass locally
- [ ] I verified dev servers for backend (8000) and frontend (4000) work together
- [ ] I ran linters/formatters (ESLint/Prettier, Black/Flake8)
- [ ] I did not change public API contracts without updating docs/tests
- [ ] I preserved indentation style and avoided unrelated reformatting
- [ ] I updated docs and changelogs if needed

## AI Contributor Acknowledgement

If AI assistance (Cursor, Copilot, Claude, etc.) was used:

- [x] I followed the repository's AI development guidelines
- [x] I performed a discovery pass before edits and minimized unrelated changes
- [x] I validated all generated code, removed speculation, and ensured correctness

## Screenshots / Test Evidence

Unit tests were run successfully in the environment. Further profiling under realistic traffic is recommended to confirm CPU reduction.

---
<a href="https://cursor.com/background-agent?bcId=bc-77d17752-3386-4b7a-b41e-818cf469eef5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-77d17752-3386-4b7a-b41e-818cf469eef5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

